### PR TITLE
Provide a gdlib-config wrapper around pkg-config if gdlib-config doesn't exist but pkg-config can be found.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -84,7 +84,11 @@ TEA_ADD_TCL_SOURCES([])
 
 AC_PATH_PROGS(GDLIB_CONFIG, gdlib-config)
 if test "${GDLIB_CONFIG}" = ""; then
-    AC_MSG_ERROR([Cannot locate program gdlib-config to determine GD library paths.  Make sure gdlib-config is in PATH or set GDLIB_CONFIG env var to path to gdlib-config.])
+    if test -z "$(pkg-config --modversion gdlib)"; then
+        AC_MSG_ERROR([Cannot locate program gdlib-config to determine GD library paths, or use pkg-config to emulate gdlib-config.  Make sure gdlib-config is in PATH or set GDLIB_CONFIG env var to path to gdlib-config.])
+    else
+	GDLIB_CONFIG="$(pwd)/gdlib-config"
+    fi
 fi
 
 GD_VERSION="`${GDLIB_CONFIG} --version`"

--- a/gdlib-config
+++ b/gdlib-config
@@ -14,7 +14,7 @@ case "$1" in
 		pkg-config --modversion gdlib | awk -F"." '{print $3}'
 		;;
 	"--includes")
-		pkg-config --variable=includedir gdlib
+		echo "-I`pkg-config --variable=includedir gdlib`"
 		;;
 	"--ldflags")
 		echo "-L`pkg-config --variable=libdir gdlib`"

--- a/gdlib-config
+++ b/gdlib-config
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+case "$1" in
+	"--version")
+		pkg-config --modversion gdlib
+		;;
+	"--majorversion")
+		pkg-config --modversion gdlib | awk -F"." '{print $1}'
+		;;
+	"--minorversion")
+		pkg-config --modversion gdlib | awk -F"." '{print $2}'
+		;;
+	"--revision")
+		pkg-config --modversion gdlib | awk -F"." '{print $3}'
+		;;
+	"--includes")
+		pkg-config --variable=includedir gdlib
+		;;
+	"--ldflags")
+		echo "-L`pkg-config --variable=libdir gdlib`"
+		;;
+	"--cflags")
+		echo "-I`pkg-config --variable=includedir gdlib`"
+		;;
+	"--libs")
+		pkg-config --libs gdlib
+		;;
+	*)
+		echo
+		;;
+esac


### PR DESCRIPTION
This lets tcl.gd continue to work with older gdlib while supporting the new version.