### PR TITLE
Specify library name when loading

### DIFF
--- a/pkgIndex.tcl.in
+++ b/pkgIndex.tcl.in
@@ -2,4 +2,4 @@
 # Tcl package index file for tclgd @PACKAGE_VERSION@
 #
 package ifneeded tclgd @PACKAGE_VERSION@ \
-    [list load [file join $dir @PKG_LIB_FILE@]]
+    [list load [file join $dir @PKG_LIB_FILE@] Tclgd]


### PR DESCRIPTION
Fixes flightaware/tcl.gd#7 credit to @PaulObermeier